### PR TITLE
Fix `RND1Config`

### DIFF
--- a/rnd/configuration_rnd.py
+++ b/rnd/configuration_rnd.py
@@ -75,9 +75,11 @@ class RND1Config(PretrainedConfig):
         # Force non-causal and no caching for RND1
         kwargs["use_cache"] = False
         kwargs["is_causal"] = False
-        self.set_config_defaults()
 
         super().__init__(**kwargs)
+
+        # Set defaults after pretrained init to prevent overrides
+        self.set_config_defaults()
 
         # QoL: set attn impl directly from config
         if "attn_implementation" in kwargs:


### PR DESCRIPTION
Fix `RND1Config`

- Don't inherit from `Qwen3MoeConfig` since its defaults are incorrect
- Explicitly set defaults according to the config from final cooldown checkpoint