### PR TITLE
fix: register RND1 checkpoint conversion for Transformers 5.13+

### DIFF
--- a/rnd/modeling_rnd.py
+++ b/rnd/modeling_rnd.py
@@ -23,7 +23,10 @@ import torch
 from torch import nn
 from transformers.cache_utils import Cache
 from transformers.configuration_utils import PretrainedConfig
-from transformers.conversion_mapping import _MODEL_TO_CONVERSION_PATTERN
+from transformers.conversion_mapping import (
+    get_checkpoint_conversion_mapping,
+    register_checkpoint_conversion_mapping,
+)
 from transformers.generation import GenerationConfig
 from transformers.modeling_outputs import MaskedLMOutput, MoeModelOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
@@ -42,7 +45,9 @@ from .generation_utils import RND1GenerationMixin
 # Register rnd1 to use the same checkpoint weight conversion as qwen2_moe.
 # This enables automatic fusion of per-expert weights (experts.N.{gate,up,down}_proj)
 # into the 3D tensor format (experts.{gate_up_proj, down_proj}) used by Qwen3MoeExperts.
-_MODEL_TO_CONVERSION_PATTERN["rnd1"] = "qwen2_moe"
+register_checkpoint_conversion_mapping(
+    "rnd1", get_checkpoint_conversion_mapping("qwen2_moe"), overwrite=True
+)
 
 logger = logging.get_logger(__name__)
 


### PR DESCRIPTION
## Overview

This PR fixes RND1 checkpoint loading by explicitly registering its Qwen2-MoE conversion mapping with Transformers. This ensures the separate expert weights are correctly fused instead of being reported as missing or unexpected.

## Background

I was trying to run the demo script from the "Quick Start" section using the command below after following the install instructions:

```bash
python demo_rnd_generation.py --prompt "Write a Python function that finds the longest common subsequence of two strings. Include comments explaining the algorithm."
```

Later, I ran into the following issue during model loading:

```text
Key                                                          | Status     |
-------------------------------------------------------------+------------+-
model.layers.{0...47}.mlp.experts.{0...127}.down_proj.weight | UNEXPECTED |
model.layers.{0...47}.mlp.experts.{0...127}.up_proj.weight   | UNEXPECTED |
model.layers.{0...47}.mlp.experts.{0...127}.gate_proj.weight | UNEXPECTED |
model.layers.{0...47}.mlp.experts.gate_up_proj               | MISSING    |
model.layers.{0...47}.mlp.experts.down_proj                  | MISSING    |
```

I traced the issue to `_MODEL_TO_CONVERSION_PATTERN["rnd1"] = "qwen2_moe"` line.

https://github.com/huggingface/transformers/pull/46876 introduced a check that skips conversion mappings for custom model implementations unless they are explicitly registered with `register_checkpoint_conversion_mapping`. As a result, updating `_MODEL_TO_CONVERSION_PATTERN` no longer causes the conversion to be applied to RND1 for Transformers versions 5.13 and later. See the [conversion mapping documentation](https://huggingface.co/docs/transformers/main/en/weightconverter#registering-a-conversion-mapping) for details.

This PR replaces the private mapping mutation with an explicit checkpoint-conversion registration call and restores the expected behavior.

## Validation

Tested on an NVIDIA A100 with Python 3.12, Transformers 5.15.0, and Torch 2.13.0. The checkpoint loaded all 531 weight entries without missing or unexpected expert parameters.